### PR TITLE
Update 14. 考虑实现Comparable接口.md

### DIFF
--- a/docs/notes/14. 考虑实现Comparable接口.md
+++ b/docs/notes/14. 考虑实现Comparable接口.md
@@ -71,11 +71,11 @@ public final class CaseInsensitiveString
 ```java
 // Multiple-field `Comparable` with primitive fields
 public int compareTo(PhoneNumber pn) {
-    int result = [Short.compare(areaCode](http://Short.compare(areaCode), pn.areaCode);
-    if (result == 0)  {
-        result = [Short.compare(prefix](http://Short.compare(prefix), pn.prefix);
+    int result = Short.compare(areaCode, pn.areaCode);
+    if (result == 0) {
+        result = Short.compare(prefix, pn.prefix);
         if (result == 0)
-            result = [Short.compare(lineNum](http://Short.compare(lineNum), pn.lineNum);
+            result = Short.compare(lineNum, pn.lineNum);
     }
     return result;
 }


### PR DESCRIPTION
wrong  snippets in `compareTo` method for the `PhoneNumber` class